### PR TITLE
Replace Hardcoded Backend Links with Environment Variable for API URL

### DIFF
--- a/src/pages/RecipePage/RecipePage.jsx
+++ b/src/pages/RecipePage/RecipePage.jsx
@@ -6,9 +6,11 @@ import Fraction from "fraction.js";
 import { Link, useNavigate } from "react-router-dom";
 import StarRatings from "react-star-ratings";
 import { calculateAverageRating } from "../../utils/formatHelper";
-import { Star, LightbulbFilament, CaretLeft } from "@phosphor-icons/react";
+import { LightbulbFilament, CaretLeft } from "@phosphor-icons/react";
 
 const RecipePage = () => {
+  const apiUrl = import.meta.env.VITE_API_URL;
+
   const navigate = useNavigate();
   const starSize = 18;
 
@@ -22,9 +24,7 @@ const RecipePage = () => {
       if (!recipeId) return;
 
       try {
-        const response = await axios.get(
-          `http://localhost:3003/api/recipes/${recipeId}`,
-        );
+        const response = await axios.get(`${apiUrl}/api/recipes/${recipeId}`);
         setRecipe(response.data);
         setIsLoading(false);
       } catch (error) {

--- a/src/pages/signup/SignUp.jsx
+++ b/src/pages/signup/SignUp.jsx
@@ -22,6 +22,7 @@ const schema = yup.object().shape({
 });
 
 const SignUp = () => {
+  const apiUrl = import.meta.env.VITE_API_URL;
   const {
     register,
     handleSubmit,
@@ -58,7 +59,7 @@ const SignUp = () => {
       };
 
       const response = await axios.post(
-        "http://localhost:3003/api/users/register",
+        `${apiUrl}/api/users/register`,
         formattedData,
       );
 


### PR DESCRIPTION
## Description

This PR removes hardcoded backend links (`localhost:3003`) and replaces them with an environment variable, improving flexibility and ensuring compatibility for deployment.

### Changes Made
1. **Replaced Hardcoded URLs**:  
   - Replaced `http://localhost:3003` with `import.meta.env.VITE_API_URL`, making the backend URL configurable through environment variables.
2. **Environment Variable Setup**:  
   - Updated code to dynamically reference the API URL from the `.env` file (`VITE_API_URL`).
3. **Deployment Readiness**:  
   - This change ensures the app will work seamlessly in different environments (local, staging, production) without requiring code changes.

---

## Why These Changes Are Necessary
- Hardcoding backend URLs (`localhost:3003`) limits the application's ability to adapt to different environments.
- Using an environment variable (`VITE_API_URL`) makes the app ready for deployment and allows easier management of API endpoints.

---

## Testing Steps

### Manual Testing
1. Set up a `.env` file with the `VITE_API_URL` variable pointing to your backend, e.g.:  
   ```env
   VITE_API_URL=https://your-backend-url.com