### PR TITLE
Fix broken link in `ReviewPostCard` by updating path to use `recipeId`

### DIFF
--- a/src/components/TypesOfRecipeCards/ReviewPostCard.jsx
+++ b/src/components/TypesOfRecipeCards/ReviewPostCard.jsx
@@ -9,7 +9,7 @@ const ReviewPostCard = ({ review }) => {
         <PostBadge>Review</PostBadge>
 
         <figure>
-          <Link to={`/recipe/${review.id}`}>
+          <Link to={`/recipe/${review.recipe.id}`}>
             <img
               src={review.imageUrl}
               className="h-[220px] w-full rounded-3xl object-cover"


### PR DESCRIPTION


### **Description**
- Resolved an issue where `ReviewPostCard` links were incorrectly using `reviewId` in the path, leading to a broken page.  
- Updated the pathing logic to use `recipeId`, ensuring the links now direct to the correct page.  

---

### **Changes Made**
1. Updated the `ReviewPostCard` component to replace `reviewId` with `recipeId` in the URL path.  
2. Verified functionality by testing navigation to the correct pages.  

---